### PR TITLE
Remove yearly (APRIL 25) Cronjob - set Downpage #11976

### DIFF
--- a/.github/workflows/downpage-off.yaml
+++ b/.github/workflows/downpage-off.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         
         with:
-          type: "Sucessfully"
+          type: ${{ job.status }}
           job_name: "Downpage is OFF on ${{env.TAG_NAME}}*"
           channel: "#registries-ops"
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}

--- a/.github/workflows/downpage-off.yaml
+++ b/.github/workflows/downpage-off.yaml
@@ -19,18 +19,18 @@ jobs:
           echo "TAG_NAME=${{ github.event.inputs.environement }}" >> $GITHUB_ENV
       - name: Login Openshift and turn off downpage
         run: |
-          #oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}          
-          #oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "search-web-prod"}, "port": {"targetPort": "search-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          #oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "namerequest-prod"}, "port": {"targetPort": "namerequest-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          #oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "business-filings-prod"}, "port": {"targetPort": "business-filings-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          #oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "auth-web-prod"}, "port": {"targetPort": "auth-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}          
+          oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "search-web-prod"}, "port": {"targetPort": "search-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "namerequest-prod"}, "port": {"targetPort": "namerequest-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "business-filings-prod"}, "port": {"targetPort": "business-filings-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "auth-web-prod"}, "port": {"targetPort": "auth-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
 
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         
         with:
           type: ${{ job.status }}
-          job_name: "Downpage is OFF on ${{env.TAG_NAME}}*"
+          job_name: "*Downpage is OFF on ${{env.TAG_NAME}}*"
           channel: "#registries-ops"
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
           commit: true

--- a/.github/workflows/downpage-off.yaml
+++ b/.github/workflows/downpage-off.yaml
@@ -19,8 +19,7 @@ jobs:
           echo "TAG_NAME=${{ github.event.inputs.environement }}" >> $GITHUB_ENV
       - name: Login Openshift and turn off downpage
         run: |
-          oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}
-          oc patch route bc-registry-namerequest-dev -p '{"spec": {"to": {"name": "namerequest-dev"}, "port": {"targetPort": "namerequest-dev-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-dev
+          #oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}          
           #oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "search-web-prod"}, "port": {"targetPort": "search-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
           #oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "namerequest-prod"}, "port": {"targetPort": "namerequest-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
           #oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "business-filings-prod"}, "port": {"targetPort": "business-filings-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod

--- a/.github/workflows/downpage-off.yaml
+++ b/.github/workflows/downpage-off.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         
         with:
-          type: ""
+          type: "Sucessfully"
           job_name: "Downpage is OFF on ${{env.TAG_NAME}}*"
           channel: "#registries-ops"
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}

--- a/.github/workflows/downpage-off.yaml
+++ b/.github/workflows/downpage-off.yaml
@@ -20,7 +20,19 @@ jobs:
       - name: Login Openshift and turn off downpage
         run: |
           oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}
-          oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "search-web-prod"}, "port": {"targetPort": "search-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "namerequest-prod"}, "port": {"targetPort": "namerequest-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "business-filings-prod"}, "port": {"targetPort": "business-filings-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "auth-web-prod"}, "port": {"targetPort": "auth-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-namerequest-dev -p '{"spec": {"to": {"name": "namerequest-dev"}, "port": {"targetPort": "namerequest-dev-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-dev
+          #oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "search-web-prod"}, "port": {"targetPort": "search-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          #oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "namerequest-prod"}, "port": {"targetPort": "namerequest-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          #oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "business-filings-prod"}, "port": {"targetPort": "business-filings-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          #oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "auth-web-prod"}, "port": {"targetPort": "auth-web-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+
+      - name: Rocket.Chat Notification
+        uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
+        
+        with:
+          type: ""
+          job_name: "Downpage is OFF on ${{env.TAG_NAME}}*"
+          channel: "#registries-ops"
+          url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
+          commit: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/downpage-on.yaml
+++ b/.github/workflows/downpage-on.yaml
@@ -1,8 +1,6 @@
 name: Turn on downpage
 
 on:
-  schedule:
-    - cron: "40 11 25 04 *"
   workflow_dispatch:
     inputs:
       environement:
@@ -25,7 +23,19 @@ jobs:
       - name: Login Openshift and Turn on downpage
         run: |
           oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}
-          oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-namerequest-dev -p '{"spec": {"to": {"name": "downpage-dev"}, "port": {"targetPort": "namerequest-dev-tcp"}}}'
+          #oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          #oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          #oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          #oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+
+      - name: Rocket.Chat Notification
+        uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
+        
+        with:
+          type: ""
+          job_name: "Downpage is ON on ${{env.TAG_NAME}}*"
+          channel: "#registries-ops"
+          url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
+          commit: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/downpage-on.yaml
+++ b/.github/workflows/downpage-on.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         
         with:
-          type: ""
+          type: "Sucessfully"
           job_name: "Downpage is ON on ${{env.TAG_NAME}}*"
           channel: "#registries-ops"
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}

--- a/.github/workflows/downpage-on.yaml
+++ b/.github/workflows/downpage-on.yaml
@@ -22,18 +22,18 @@ jobs:
           echo "TAG_NAME=prod" >> $GITHUB_ENV
       - name: Login Openshift and Turn on downpage
         run: |
-          #oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}          
-          #oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          #oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          #oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
-          #oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}          
+          oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
+          oc patch route bc-registry-auth-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
 
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         
         with:
           type: ${{ job.status }}
-          job_name: "Downpage is ON on ${{env.TAG_NAME}}*"
+          job_name: "*Downpage is ON on ${{env.TAG_NAME}}*"
           channel: "#registries-ops"
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
           commit: true

--- a/.github/workflows/downpage-on.yaml
+++ b/.github/workflows/downpage-on.yaml
@@ -22,8 +22,7 @@ jobs:
           echo "TAG_NAME=prod" >> $GITHUB_ENV
       - name: Login Openshift and Turn on downpage
         run: |
-          oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}
-          oc patch route bc-registry-namerequest-dev -p '{"spec": {"to": {"name": "downpage-dev"}, "port": {"targetPort": "namerequest-dev-tcp"}}}'
+          #oc login --server=${{secrets.OPENSHIFT4_LOGIN_REGISTRY}} --token=${{secrets.OPENSHIFT4_SA_TOKEN}}          
           #oc patch route bc-registry-search-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
           #oc patch route bc-registry-namerequest-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod
           #oc patch route bc-registry-business-prod -p '{"spec": {"to": {"name": "downpage-prod"}, "port": {"targetPort": "downpage-prod-tcp"}}}' -n ${{secrets.OPENSHIFT4_NAMESPACE_FRONTEND}}-prod

--- a/.github/workflows/downpage-on.yaml
+++ b/.github/workflows/downpage-on.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         
         with:
-          type: "Sucessfully"
+          type: ${{ job.status }}
           job_name: "Downpage is ON on ${{env.TAG_NAME}}*"
           channel: "#registries-ops"
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}


### PR DESCRIPTION
*Issue #:* /bcgov/entity### Downpage was on automatically on PROD by cron

*Description of changes:*
1. Removed the cron from action
2. Added GITHUB ACTIONS to POST IN OPS CHANNEL when Downpage is set on or off.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
