### PR TITLE
Fixed the mutilple emails validation error issue.

### DIFF
--- a/notify-api/src/notify_api/services/providers/gc_notify.py
+++ b/notify-api/src/notify_api/services/providers/gc_notify.py
@@ -55,11 +55,13 @@ class GCNotify:
                         'sending_method': 'attach'
                     }
 
-            client.send_email_notification(
-                email_address=self.notification.recipients,
-                template_id=self.gc_notify_template_id,
-                personalisation=email_content
-            )
+            # send one email at a time
+            for recipient in self.notification.recipients.split(','):
+                client.send_email_notification(
+                    email_address=recipient,
+                    template_id=self.gc_notify_template_id,
+                    personalisation=email_content
+                )
 
         except Exception as err:  # pylint: disable=broad-except # noqa F841;
             # bypass team-only API key bad request error


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Recently, GC Notify don't allow the multiple emails in one email. We have to send the email one by one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
