### PR TITLE
set secret environment

### DIFF
--- a/.github/workflows/restart-services.yaml
+++ b/.github/workflows/restart-services.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   restart-services:
     runs-on: ubuntu-20.04
-
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v3
       - name: Set env by input
@@ -102,18 +102,18 @@ jobs:
         run: |
           oc scale --replicas=0 dc/events-listener-${{ env.TAG_NAME }} -n 6e0e49-${{ env.TAG_NAME }}
           oc scale --replicas=1 dc/events-listener-${{ env.TAG_NAME }} -n 6e0e49-${{ env.TAG_NAME }}
-          
+
       - name: Restart search-solr-updater
         run: |
           oc scale --replicas=0 dc/search-solr-updater-${{ env.TAG_NAME }} -n 6e0e49-${{ env.TAG_NAME }}
-          oc scale --replicas=1 dc/search-solr-updater-${{ env.TAG_NAME }} -n 6e0e49-${{ env.TAG_NAME }}          
+          oc scale --replicas=1 dc/search-solr-updater-${{ env.TAG_NAME }} -n 6e0e49-${{ env.TAG_NAME }}
 
       - name: Restart solr-names-updater
         run: |
           oc scale --replicas=0 dc/solr-names-updater-${{ env.TAG_NAME }} -n f2b77c-${{ env.TAG_NAME }}
-          oc scale --replicas=1 dc/solr-names-updater-${{ env.TAG_NAME }} -n f2b77c-${{ env.TAG_NAME }} 
+          oc scale --replicas=1 dc/solr-names-updater-${{ env.TAG_NAME }} -n f2b77c-${{ env.TAG_NAME }}
 
       - name: Restart bor-solr-updater
         run: |
           oc scale --replicas=0 dc/bor-solr-updater-${{ env.TAG_NAME }} -n 1dfe78-${{ env.TAG_NAME }}
-          oc scale --replicas=1 dc/bor-solr-updater-${{ env.TAG_NAME }} -n 1dfe78-${{ env.TAG_NAME }} 
+          oc scale --replicas=1 dc/bor-solr-updater-${{ env.TAG_NAME }} -n 1dfe78-${{ env.TAG_NAME }}


### PR DESCRIPTION
*Description of changes:*
OCP service account secret has 3 environments, which are not selected correctly (prod account is used for all environments).

Relevant docs:
https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#using-an-environment

More inspiration:
https://stackoverflow.com/questions/66521958/how-to-access-environment-secrets-from-a-github-workflow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
