### PR TITLE
handle cors preflight without auth

### DIFF
--- a/notify-api/src/notify_api/resources/v2/safe_list.py
+++ b/notify-api/src/notify_api/resources/v2/safe_list.py
@@ -25,7 +25,7 @@ from notify_api.utils.logging import logger
 bp = Blueprint("SAFE_LIST", __name__, url_prefix="/safe_list")
 
 
-@bp.route("/", methods=["POST", "OPTIONS"])
+@bp.route("/", methods=["POST"])
 @jwt.requires_auth
 @jwt.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value])
 @validate()
@@ -40,7 +40,14 @@ def safe_list(body: SafeListRequest):  # pylint: disable=unused-argument
     return {}, HTTPStatus.OK
 
 
-@bp.route("/", methods=["GET", "OPTIONS"])
+@bp.route("/", methods=["OPTIONS"])
+@validate()
+def get_safe_list_preflight():
+    """Handle safe list cors preflight."""
+    return {}, HTTPStatus.OK
+
+
+@bp.route("/", methods=["GET"])
 @jwt.requires_auth
 @jwt.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value])
 @validate()


### PR DESCRIPTION
*Description of changes:* Currently dashboard view of safe list is not working, e.g. see https://github.com/bcgov/entity/issues/20463

This is a regression due to moving notify-api and ui to different domains.

Cors preflight mechanism kicks in because of domain difference, and is consequently failing because the endpoint is expecting auth token (while preflight does not supply auth tokens by design).

<img width="970" alt="Screenshot 2024-04-09 at 10 26 55 AM" src="https://github.com/bcgov/bcregistry-sre/assets/22973013/cb4bfddd-cc48-42a7-9ad7-fe3b5857f576">

Failing preflight request causes the original request to fail

See (see https://cloud.google.com/functions/docs/writing/write-http-functions#cors-limitations):

"CORS limitations
For preflighted cross-origin requests, preflight OPTIONS requests are sent without an Authorization header, so they will be rejected on all HTTP functions that require authentication. Because the preflight requests fail, the main requests will also fail. To work around this limitation, use one of the following options:
* [Allow unauthenticated invocations](https://cloud.google.com/functions/docs/securing/managing-access-iam#allowing_unauthenticated_http_function_invocation) of your function.
* Host your web app and Cloud Functions on the same domain to avoid CORS. You can do this by [integrating Firebase Hosting with Cloud Functions](https://firebase.google.com/docs/hosting/functions)."


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
