### PR TITLE
read CPU_THROTTLE flag from 1password, if it exists and set to false,…

### DIFF
--- a/.github/actions/cloud-deploy/files/cloudbuild.yaml
+++ b/.github/actions/cloud-deploy/files/cloudbuild.yaml
@@ -33,10 +33,23 @@ steps:
       for env_name in "${targets[@]}"; do
         export APP_ENV=${env_name}
         op inject  -f -i ./devops/vaults.gcp.env -o ./devops/vaults.${env_name}
+
+        CPU_THROTTLING=$(awk -F '=' '/^CPU_THROTTLING/ {print $2}' ./devops/vaults.${env_name})
+        if [ -z "$CPU_THROTTLING" ]; then
+          CPU_THROTTLING="true"
+        fi
+
+        # Set the cpu-throttling annotation based on the CPU_THROTTLING value
+        if [ "$CPU_THROTTLING" = "true" ]; then
+          yq e '.spec.template.metadata.annotations["run.googleapis.com/cpu-throttling"] = "true"' ./devops/gcp/k8s/service.template.yaml > ./devops/gcp/k8s/service.${env_name}.yaml
+        else
+          yq e '.spec.template.metadata.annotations["run.googleapis.com/cpu-throttling"] = "false"' ./devops/gcp/k8s/service.template.yaml > ./devops/gcp/k8s/service.${env_name}.yaml
+        fi
+
         export VAL=$(awk '{f1=f2=$0; sub(/=.*/,"",f1); sub(/[^=]+=/,"",f2); printf "- name: %s\n  value: %s\n",f1,f2}' ./devops/vaults.${env_name} | sed 's/\"/\"/g')
 
         # generate manifest for each environment
-        yq e '.spec.template.spec.containers[0].env += env(VAL)' ./devops/gcp/k8s/service.template.yaml > ./devops/gcp/k8s/service.${env_name}.yaml
+        yq e '.spec.template.spec.containers[0].env += env(VAL)' ./devops/gcp/k8s/service.${env_name}.yaml
 
         # sidecard OAS proxy service, only Test environment need this service
         #if [[ "$env_name" != "test" ]]; then


### PR DESCRIPTION
… then always allocate cpu to cloudrun avoiding startup lag

Setting run.googleapis.com/cpu-throttling to false in cloudrun yaml is equivalent to 'CPU is always allocated' toggle in the UI.
This can be selectively used for prod deployments, when container startup is too slow.

*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
