### PR TITLE
use custom postgres image

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -129,7 +129,7 @@ jobs:
       STAFF_ADMIN_EMAIL: "test@test.com"
     services:
       postgres:
-        image: postgis/postgis:15-master
+        image: ghcr.io/bcgov/postgres15-postgis-anon
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/images/postgres-ci/Dockerfile
+++ b/images/postgres-ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM postgis/postgis:15-master
+
+RUN apt-get update && apt-get install -y curl lsb-release && echo deb http://apt.dalibo.org/labs $(lsb_release -cs)-dalibo main > /etc/apt/sources.list.d/dalibo-labs.list \
+&& curl -fsSL -o /etc/apt/trusted.gpg.d/dalibo-labs.gpg https://apt.dalibo.org/labs/debian-dalibo.gpg && apt update
+
+RUN apt install -y postgresql_anonymizer_15
+
+CMD ["postgres"]

--- a/images/postgres-ci/build.sh
+++ b/images/postgres-ci/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker build --no-cache -t postgres15-postgis-anon .
+docker tag postgres15-postgis-anon ghcr.io/bcgov/postgres15-postgis-anon:latest
+docker push ghcr.io/bcgov/postgres15-postgis-anon:latest


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

Need postgres image to have both postgis and anon extensions installed. Postgis enabled image was used previously, need anon to for masking rules to work: https://github.com/bcgov/STRR/pull/559

Hence need custom image, which can be hosted in: https://github.com/orgs/bcgov/packages

The new image is here (with public visibility): https://github.com/orgs/bcgov/packages/container/postgres15-postgis-anon/settings

Verified that is works with https://github.com/bolyachevets/STRR/actions/runs/13445857705/job/37571081335
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
