### PR TITLE
handle delay in revision status

### DIFF
--- a/.github/actions/backend-deploy/files/cloudbuild.yaml
+++ b/.github/actions/backend-deploy/files/cloudbuild.yaml
@@ -287,12 +287,25 @@ steps:
           --region="${_REGION}" \
           --project="$PROJECT_ID" \
           --filter="metadata.labels.release-id:${RELEASE_NAME}" \
-          --format="json" | jq -r '.[].status.conditions[] | select(.type == "Ready") | .status')
-
+          --format="json" | jq -r '
+            if length == 0 then
+              "NotFound"
+            else
+              (.[0].status.conditions // [])
+              | map(select(.type == "Ready")
+              | if length > 0 then
+                  .[0].status
+                else
+                  "Pending"
+                end
+            end
+          ')
         case "$RELEASE_STATUS" in
-          True)  echo "✅ Release ${RELEASE_NAME} completed successfully."; break ;;
-          False) echo "❌ Release ${RELEASE_NAME} failed."; exit 1 ;;
-          *)     echo "🔄 Release in progress... (Attempt ${i}/${MAX_RETRIES})"; sleep "$RETRY_INTERVAL" ;;
+          "True")   echo "✅ Ready"; break ;;
+          "False")  echo "❌ Failed"; exit 1 ;;
+          "Pending") echo "🔄 Still deploying..."; sleep "$RETRY_INTERVAL" ;;
+          "NotFound") echo "🔍 Revision not created yet"; sleep "$RETRY_INTERVAL" ;;
+          *) echo "⚠️ Unexpected: $RELEASE_STATUS"; sleep "$RETRY_INTERVAL" ;;
         esac
       done
 


### PR DESCRIPTION
*Description of changes:*
Looks like there might be a brief period where status.conditions may not be fully defined or populated in the revision's JSON response 

Step #2: jq: error (at <stdin>:155): Cannot iterate over null (null)

https://github.com/bcgov/sbc-auth/actions/runs/14229343367/job/39876353744


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
