### PR TITLE
potential fixes to tf configs

### DIFF
--- a/gcp/terraform/project_account_bindings.auto.tfvars
+++ b/gcp/terraform/project_account_bindings.auto.tfvars
@@ -1346,13 +1346,6 @@ projects = {
       sa-api = {
         roles       = ["projects/k973yf-test/roles/roleapi"]
         description = "Service Account for running api services"
-        resource_roles = [
-            {
-              resource = "projects/k973yf-test/locations/northamerica-northeast1/services/namex-solr-synonyms-api-dev"
-              roles    = ["roles/run.invoker"]
-              resource_type = "cloud_run"
-            }
-          ]
       },
       sa-queue = {
         roles       = ["projects/k973yf-test/roles/rolequeue"]
@@ -1998,13 +1991,6 @@ projects = {
       sa-api = {
         roles       = ["projects/k973yf-dev/roles/roleapi"]
         description = "Service Account for running api services"
-        resource_roles = [
-            {
-              resource = "projects/k973yf-dev/locations/northamerica-northeast1/services/namex-solr-synonyms-api-dev"
-              roles    = ["roles/run.invoker"]
-              resource_type = "cloud_run"
-            }
-          ]
       },
       sa-queue = {
         roles       = ["projects/k973yf-dev/roles/rolequeue"]
@@ -2320,7 +2306,7 @@ projects = {
     }
   }
   "search-sandbox" = {
-    project_id = "k973yf-tools"
+    project_id = "k973yf--tools"
     env = "sandbox"
     instances = [
       {
@@ -2345,22 +2331,15 @@ projects = {
         description = "Service Account for running pubsub services"
       },
       sa-job = {
-        roles       = ["projects/k973yf-tools/roles/rolejob"]
+        roles       = ["projects/k973yf--tools/roles/rolejob"]
         description = "Service Account for running job services"
       },
       sa-api = {
-        roles       = ["projects/k973yf-tools/roles/roleapi"]
+        roles       = ["projects/k973yf--tools/roles/roleapi"]
         description = "Service Account for running api services"
-        resource_roles = [
-            {
-              resource = "projects/k973yf-tools/locations/northamerica-northeast1/services/namex-solr-synonyms-api-dev"
-              roles    = ["roles/run.invoker"]
-              resource_type = "cloud_run"
-            }
-          ]
       },
       sa-queue = {
-        roles       = ["projects/k973yf-tools/roles/rolequeue"]
+        roles       = ["projects/k973yf--tools/roles/rolequeue"]
         description = "Service Account for running queue services"
       },
       gha-wif = {
@@ -2372,7 +2351,7 @@ projects = {
         }]
         resource_roles = [
           {
-            resource = "projects/k973yf-tools/serviceAccounts/854458797060-compute@developer.gserviceaccount.com"
+            resource = "projects/k973yf--tools/serviceAccounts/854458797060-compute@developer.gserviceaccount.com"
             roles    = ["roles/iam.serviceAccountUser"]
             resource_type = "sa_iam_member"
           }
@@ -2732,7 +2711,7 @@ projects = {
         },
         {
           roles      = ["roles/cloudsql.admin"]
-          project_id = "k973yf-tools"
+          project_id = "k973yf--tools"
         },
         {
           roles      = ["roles/cloudsql.admin"]


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

namex-solr-synonyms-api-dev does not exist in search project, do we actually want to call it?

search project id actually has '--' in sandbox
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
