### PR TITLE
Update backend-cronjob-cd-ocp.yaml for cronjob so VCS_REF and BUILD_DATE works

### DIFF
--- a/.github/workflows/backend-cronjob-cd-ocp.yaml
+++ b/.github/workflows/backend-cronjob-cd-ocp.yaml
@@ -140,8 +140,8 @@ jobs:
         run: |-
           docker build . -t ${APP_NAME} \
             --platform linux/amd64 \
-            --build-arg VCS_REF=$(shell git rev-parse --short HEAD) \
-            --build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+            --build-arg VCS_REF=$(git rev-parse --short HEAD) \
+            --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "${SA_TOKEN}" | docker login ${DOCKER_REGISTRY} -u ${SA_NAME} --password-stdin
           docker tag ${APP_NAME} ${REGISTRY_IMAGE}:latest
           docker push ${REGISTRY_IMAGE}:latest


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
