### PR TITLE
Docker build kit set to 1.

### DIFF
--- a/.github/actions/backend-deploy/files/cloudbuild.yaml
+++ b/.github/actions/backend-deploy/files/cloudbuild.yaml
@@ -160,6 +160,7 @@ steps:
       TARGET_FROM="${PROJECT_NAME}-${_DEPLOYMENT_ENV_FROM:-}"
       IMAGE_PATH="${_REGION}-docker.pkg.dev/${_BUILD_PROJECT}/cloud-run-repo/${_APP_NAME}"
       IMAGE_PACKAGE_PATH="projects/${_BUILD_PROJECT}/locations/${_REGION}/repositories/cloud-run-repo/packages/${_APP_NAME}"
+      DOCKER_BUILDKIT=1
 
       # 🧩 Function to check if a Docker tag exists
       tag_exists() {


### PR DESCRIPTION
See PR253 

Set DOCKER_BUILDKIT=1 for cloudbuild.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
