### PR TITLE
Ahamood1 27110 sa invoker cloud run

### DIFF
--- a/gcp/terraform/project_account_bindings.auto.tfvars
+++ b/gcp/terraform/project_account_bindings.auto.tfvars
@@ -1139,6 +1139,11 @@ projects = {
               resource_type = "cloud_run"
             },
             {
+              resource = "projects/a083gt-test/locations/northamerica-northeast1/services/namex-api-test"
+              roles    = ["roles/run.invoker"]
+              resource_type = "cloud_run"
+            },
+            {
               resource = "projects/a083gt-test/topics/namex-emailer-test"
               roles    = ["roles/pubsub.publisher"]
               resource_type = "pubsub_topic"

--- a/gcp/terraform/project_account_bindings.auto.tfvars
+++ b/gcp/terraform/project_account_bindings.auto.tfvars
@@ -429,6 +429,11 @@ projects = {
               resource_type = "cloud_run"
             },
             {
+              resource = "projects/a083gt-prod/locations/northamerica-northeast1/services/namex-api-prod"
+              roles    = ["roles/run.invoker"]
+              resource_type = "cloud_run"
+            },
+            {
               resource = "projects/a083gt-prod/topics/namex-emailer-prod"
               roles    = ["roles/pubsub.publisher"]
               resource_type = "pubsub_topic"

--- a/gcp/terraform/project_account_bindings.auto.tfvars
+++ b/gcp/terraform/project_account_bindings.auto.tfvars
@@ -1863,6 +1863,11 @@ projects = {
               resource_type = "cloud_run"
             },
             {
+              resource = "projects/a083gt-dev/locations/northamerica-northeast1/services/namex-api-dev"
+              roles    = ["roles/run.invoker"]
+              resource_type = "cloud_run"
+            },
+            {
               resource = "projects/a083gt-dev/topics/namex-emailer-dev"
               roles    = ["roles/pubsub.publisher"]
               resource_type = "pubsub_topic"


### PR DESCRIPTION
*Issue #27110:* 

*Description of changes:*
- The sa-api account was originally part of namex-solr-synonyms-api-dev.
  This PR adds sa-api to namex-api-dev.
- The sa-api account was also originally part of namex-solr-synonyms-api-test.
  This PR adds sa-api to namex-api-test.
- The sa-api account was also originally part of namex-solr-synonyms-api-prod.
  This PR adds sa-api to namex-api-prod.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
