### PR TITLE
21835 cloud task queue

### DIFF
--- a/gcp/terraform/_config_project_dev.auto.tfvars
+++ b/gcp/terraform/_config_project_dev.auto.tfvars
@@ -395,7 +395,7 @@ dev_projects = {
           description = "Service Account for running job services"
         },
         sa-api = {
-          roles       = ["projects/a083gt-dev/roles/roleapi", "roles/iam.serviceAccountTokenCreator"]
+          roles       = ["projects/a083gt-dev/roles/roleapi", "roles/iam.serviceAccountTokenCreator", "roles/cloudtasks.enqueuer", "roles/cloudtasks.viewer", "roles/cloudtasks.taskDeleter"]
           description = "Service Account for running api services"
           resource_roles = [
               {
@@ -446,7 +446,6 @@ dev_projects = {
       }
     }
     cloud_tasks = {
-      location = "northamerica-northeast1"
       instances = [
         {
           instance = "namex-emailer-pending-send-queue-dev"

--- a/gcp/terraform/_config_project_dev.auto.tfvars
+++ b/gcp/terraform/_config_project_dev.auto.tfvars
@@ -445,6 +445,22 @@ dev_projects = {
           description = "Service Account for solr importer services"
       }
     }
+    cloud_tasks = {
+      location = "northamerica-northeast1"
+      instances = [
+        {
+          instance = "namex-emailer-pending-send-queue-dev"
+          max_dispatches_per_second = 5
+          max_concurrent_dispatches = 100
+          max_attempts = 3
+          max_retry_duration = "60s"
+          min_backoff = "5s"
+          max_backoff = "5s"
+          max_doublings = 0
+          sampling_ratio = 1.0
+        }
+      ]
+    }
   },
   "business-number-hub-dev" = {
     project_id = "keee67-dev"

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -287,7 +287,7 @@ test_projects = {
         description = "Service Account for running job services"
       },
       sa-api = {
-        roles       = ["projects/a083gt-test/roles/roleapi", "roles/iam.serviceAccountTokenCreator"]
+        roles       = ["projects/a083gt-test/roles/roleapi", "roles/iam.serviceAccountTokenCreator", "roles/cloudtasks.enqueuer", "roles/cloudtasks.viewer", "roles/cloudtasks.taskDeleter"]
         description = "Service Account for running api services"
         resource_roles = [
             {
@@ -403,6 +403,21 @@ test_projects = {
           }
         ]
       }
+    }
+    cloud_tasks = {
+      instances = [
+        {
+          instance = "namex-emailer-pending-send-queue-dev"
+          max_dispatches_per_second = 5
+          max_concurrent_dispatches = 100
+          max_attempts = 3
+          max_retry_duration = "60s"
+          min_backoff = "5s"
+          max_backoff = "5s"
+          max_doublings = 0
+          sampling_ratio = 1.0
+        }
+      ]
     }
   },
   "ppr-test" = {

--- a/gcp/terraform/main.tf
+++ b/gcp/terraform/main.tf
@@ -101,3 +101,40 @@ module "sql_iam_users" {
     module.iam
   ]
 }
+
+
+module "cloud_tasks" {
+  for_each = {
+    for instance in flatten([
+      for project in local.projects : [
+        for instance in try(project.cloud_tasks.instances, []) : {
+          project_id = project.project_id
+          location = var.region
+          queue_name = instance.instance
+          max_dispatches_per_second = instance.max_dispatches_per_second
+          max_concurrent_dispatches = instance.max_concurrent_dispatches
+          max_attempts = instance.max_attempts
+          max_retry_duration = instance.max_retry_duration
+          min_backoff = instance.min_backoff
+          max_backoff = instance.max_backoff
+          max_doublings = instance.max_doublings
+          sampling_ratio = instance.sampling_ratio
+        }
+      ]
+    ]) : "${instance.project_id}-${instance.queue_name}" => instance
+  }
+
+  source = "./modules/cloud_tasks"
+
+  project_id = each.value.project_id
+  location   = each.value.location
+  queue_name = each.value.queue_name
+  max_dispatches_per_second = each.value.max_dispatches_per_second
+  max_concurrent_dispatches = each.value.max_concurrent_dispatches
+  max_attempts = each.value.max_attempts
+  max_retry_duration = each.value.max_retry_duration
+  min_backoff = each.value.min_backoff
+  max_backoff = each.value.max_backoff
+  max_doublings = each.value.max_doublings
+  sampling_ratio = each.value.sampling_ratio
+}

--- a/gcp/terraform/modules/cloud_tasks/main.tf
+++ b/gcp/terraform/modules/cloud_tasks/main.tf
@@ -1,0 +1,22 @@
+resource "google_cloud_tasks_queue" "cloud_tasks_queue" {
+  name     = var.queue_name
+  location = var.location
+  project  = var.project_id
+
+  rate_limits {
+    max_dispatches_per_second = var.max_dispatches_per_second
+    max_concurrent_dispatches = var.max_concurrent_dispatches
+  }
+
+  retry_config {
+    max_attempts       = var.max_attempts
+    max_retry_duration = var.max_retry_duration
+    min_backoff        = var.min_backoff
+    max_backoff        = var.max_backoff
+    max_doublings      = var.max_doublings
+  }
+
+  stackdriver_logging_config {
+    sampling_ratio = var.sampling_ratio
+  }
+} 

--- a/gcp/terraform/modules/cloud_tasks/outputs.tf
+++ b/gcp/terraform/modules/cloud_tasks/outputs.tf
@@ -1,0 +1,14 @@
+output "queue_name" {
+  description = "The name of the Cloud Tasks queue"
+  value       = google_cloud_tasks_queue.cloud_tasks_queue.name
+}
+
+output "queue_id" {
+  description = "The ID of the Cloud Tasks queue"
+  value       = google_cloud_tasks_queue.cloud_tasks_queue.id
+}
+
+output "queue_location" {
+  description = "The location of the Cloud Tasks queue"
+  value       = google_cloud_tasks_queue.cloud_tasks_queue.location
+} 

--- a/gcp/terraform/modules/cloud_tasks/variables.tf
+++ b/gcp/terraform/modules/cloud_tasks/variables.tf
@@ -1,0 +1,62 @@
+variable "project_id" {
+  description = "The ID of the project where the Cloud Tasks queue will be created"
+  type        = string
+}
+
+variable "location" {
+  description = "The location where the Cloud Tasks queue will be created"
+  type        = string
+}
+
+variable "queue_name" {
+  description = "The name of the Cloud Tasks queue"
+  type        = string
+}
+
+variable "max_dispatches_per_second" {
+  description = "The maximum number of tasks that can be dispatched per second"
+  type        = number
+  default     = 5
+}
+
+variable "max_concurrent_dispatches" {
+  description = "The maximum number of concurrent tasks that can be dispatched"
+  type        = number
+  default     = 100
+}
+
+variable "max_attempts" {
+  description = "The maximum number of attempts for a task"
+  type        = number
+  default     = 3
+}
+
+variable "max_retry_duration" {
+  description = "The maximum duration for retrying a task"
+  type        = string
+  default     = "60s"
+}
+
+variable "min_backoff" {
+  description = "The minimum backoff duration between retries"
+  type        = string
+  default     = "5s"
+}
+
+variable "max_backoff" {
+  description = "The maximum backoff duration between retries"
+  type        = string
+  default     = "5s"
+}
+
+variable "max_doublings" {
+  description = "The maximum number of times that the backoff duration can be doubled before reaching the maximum backoff"
+  type        = number
+  default     = 0
+}
+
+variable "sampling_ratio" {
+  description = "The sampling ratio for Stackdriver logging"
+  type        = number
+  default     = 1.0
+} 

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -202,6 +202,20 @@ variable "other_projects" {
       description  = optional(string, "Custom role managed by Terraform")
     })), {})
 
+    cloud_tasks = optional(map(object({
+      instances = list(object({
+        instance = string
+        max_dispatches_per_second = number
+        max_concurrent_dispatches = number
+        max_attempts = number
+        max_retry_duration = string
+        min_backoff = string
+        max_backoff = string
+        max_doublings = number
+        sampling_ratio = number
+      }))
+    })), {})
+
     pam_bindings = optional(list(object({
       role       = string
       principals = optional(list(string))


### PR DESCRIPTION
*Issue #:* /bcgov/entity[#21835](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/21835) and [#28777](https://github.com/bcgov/entity/issues/28777)

- Adds a `cloud_tasks` Terraform module.  
- Adds Cloud Tasks configurations and roles for `sa-api` to `a083gt-dev` in `_config_project_dev.auto.tfvars`.  
- Adds Cloud Tasks configurations and roles for `sa-api` to `a083gt-test` in `_config_project_test.auto.tfvars`.  
- Updates the top-level `main.tf` to integrate the Cloud Tasks module.  
- Updates the top-level `variables.tf` to include the Cloud Tasks configuration input data structure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
