### PR TITLE
feat: option for routing all traffic to vpc

### DIFF
--- a/images/sre-cd-runner/functions.sh
+++ b/images/sre-cd-runner/functions.sh
@@ -181,9 +181,12 @@ generate_manifest() {
     if [[ -n "${VPC_CONNECTOR}" ]]; then
         echo "🌐 Adding VPC connector configuration..."
         if [[ -n "${ROUTE_ALL_TO_VPC}" ]]; then
+            echo "Routing all traffic to VPC"
             yq e '.spec.template.metadata.annotations += {"run.googleapis.com/vpc-access-egress": "all-traffic", "run.googleapis.com/vpc-access-connector": env(VPC_CONNECTOR)}' -i "${temp_file}"
         else
+            echo "Routing internal traffic to VPC"
             yq e '.spec.template.metadata.annotations += {"run.googleapis.com/vpc-access-egress": "private-ranges-only", "run.googleapis.com/vpc-access-connector": env(VPC_CONNECTOR)}' -i "${temp_file}"
+        fi
     fi
 
     if [[ "${service_type}" == "service" ]]; then


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26628

*Description of changes:*
- the APIs connecting to solr load balancers need to route all traffic to the VPC so that the static IP is used (this is checked by the solr cloud armor policy)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
