### PR TITLE
Fix/payment jobs sa job pubsub permissions

### DIFF
--- a/.github/actions/frontend-deploy/files/cloudbuild.yaml
+++ b/.github/actions/frontend-deploy/files/cloudbuild.yaml
@@ -156,7 +156,7 @@ steps:
     set -euo pipefail  # Added for stricter error handling
 
     apk update
-    apk add jq
+    apk add jq python3 make g++
 
     echo "Step 2: Build application."
     

--- a/gcp/terraform/_config_project_prod.auto.tfvars
+++ b/gcp/terraform/_config_project_prod.auto.tfvars
@@ -340,33 +340,12 @@ prod_projects = {
             resource = "sre-buckets"
             roles    = ["roles/storage.objectUser"]
             resource_type = "storage_bucket"
-          },
-          {
-            resource = "projects/gtksf3-prod/topics/auth-event-prod"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-prod/topics/account-mailer-prod"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-prod/topics/namex-pay-prod"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-prod/topics/assets-pay-notification-prod"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-prod/topics/business-pay-prod"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
+          }
         ]
+        external_roles = [{
+          roles      = ["roles/pubsub.publisher"]
+          project_id = "gtksf3-prod"
+        }]
       },
       sa-notebook = {
         roles       = ["projects/c4hnrd-prod/roles/rolejob", ]
@@ -649,7 +628,32 @@ prod_projects = {
               resource = "ftp-poller-prod"
               roles    = ["roles/storage.legacyBucketWriter"]
               resource_type = "storage_bucket"
-            }
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/auth-event-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/account-mailer-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/namex-pay-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/assets-pay-notification-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/business-pay-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
         ]
       },
       sa-api = {

--- a/gcp/terraform/_config_project_prod.auto.tfvars
+++ b/gcp/terraform/_config_project_prod.auto.tfvars
@@ -624,7 +624,32 @@ prod_projects = {
               resource = "ftp-poller-prod"
               roles    = ["roles/storage.legacyBucketWriter"]
               resource_type = "storage_bucket"
-            }
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/auth-event-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/account-mailer-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/namex-pay-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/assets-pay-notification-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-prod/topics/business-pay-prod"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
         ]
       },
       sa-api = {

--- a/gcp/terraform/_config_project_prod.auto.tfvars
+++ b/gcp/terraform/_config_project_prod.auto.tfvars
@@ -340,7 +340,32 @@ prod_projects = {
             resource = "sre-buckets"
             roles    = ["roles/storage.objectUser"]
             resource_type = "storage_bucket"
-          }
+          },
+          {
+            resource = "projects/gtksf3-prod/topics/auth-event-prod"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-prod/topics/account-mailer-prod"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-prod/topics/namex-pay-prod"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-prod/topics/assets-pay-notification-prod"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-prod/topics/business-pay-prod"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
         ]
       },
       sa-notebook = {
@@ -624,32 +649,7 @@ prod_projects = {
               resource = "ftp-poller-prod"
               roles    = ["roles/storage.legacyBucketWriter"]
               resource_type = "storage_bucket"
-            },
-            {
-              resource = "projects/gtksf3-prod/topics/auth-event-prod"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-prod/topics/account-mailer-prod"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-prod/topics/namex-pay-prod"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-prod/topics/assets-pay-notification-prod"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-prod/topics/business-pay-prod"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
+            }
         ]
       },
       sa-api = {

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -121,6 +121,33 @@ test_projects = {
       sa-job = {
         roles       = ["projects/c4hnrd-test/roles/rolejob"]
         description = "Service Account for running job services"
+        resource_roles = [
+          {
+            resource = "projects/gtksf3-test/topics/auth-event-test"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-test/topics/account-mailer-test"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-test/topics/namex-pay-test"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-test/topics/assets-pay-notification-test"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+          {
+            resource = "projects/gtksf3-test/topics/business-pay-test"
+            roles    = ["roles/pubsub.publisher"]
+            resource_type = "pubsub_topic"
+          },
+        ]
       },
       sa-api = {
         roles       = ["projects/c4hnrd-test/roles/roleapi", "roles/cloudsql.instanceUser", "roles/run.serviceAgent"]
@@ -352,32 +379,7 @@ test_projects = {
               resource = "ftp-poller-test"
               roles    = ["roles/storage.legacyBucketWriter"]
               resource_type = "storage_bucket"
-            },
-            {
-              resource = "projects/gtksf3-test/topics/auth-event-test"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-test/topics/account-mailer-test"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-test/topics/namex-pay-test"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-test/topics/assets-pay-notification-test"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
-            {
-              resource = "projects/gtksf3-test/topics/business-pay-test"
-              roles    = ["roles/pubsub.publisher"]
-              resource_type = "pubsub_topic"
-            },
+            }
         ]
       },
       sa-api = {

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -352,7 +352,32 @@ test_projects = {
               resource = "ftp-poller-test"
               roles    = ["roles/storage.legacyBucketWriter"]
               resource_type = "storage_bucket"
-            }
+            },
+            {
+              resource = "projects/gtksf3-test/topics/auth-event-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/account-mailer-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/namex-pay-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/assets-pay-notification-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/business-pay-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
         ]
       },
       sa-api = {

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -121,33 +121,10 @@ test_projects = {
       sa-job = {
         roles       = ["projects/c4hnrd-test/roles/rolejob"]
         description = "Service Account for running job services"
-        resource_roles = [
-          {
-            resource = "projects/gtksf3-test/topics/auth-event-test"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-test/topics/account-mailer-test"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-test/topics/namex-pay-test"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-test/topics/assets-pay-notification-test"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-          {
-            resource = "projects/gtksf3-test/topics/business-pay-test"
-            roles    = ["roles/pubsub.publisher"]
-            resource_type = "pubsub_topic"
-          },
-        ]
+        external_roles = [{
+          roles      = ["roles/pubsub.publisher"]
+          project_id = "gtksf3-test"
+        }]
       },
       sa-api = {
         roles       = ["projects/c4hnrd-test/roles/roleapi", "roles/cloudsql.instanceUser", "roles/run.serviceAgent"]
@@ -379,7 +356,32 @@ test_projects = {
               resource = "ftp-poller-test"
               roles    = ["roles/storage.legacyBucketWriter"]
               resource_type = "storage_bucket"
-            }
+            },
+            {
+              resource = "projects/gtksf3-test/topics/auth-event-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/account-mailer-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/namex-pay-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/assets-pay-notification-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
+            {
+              resource = "projects/gtksf3-test/topics/business-pay-test"
+              roles    = ["roles/pubsub.publisher"]
+              resource_type = "pubsub_topic"
+            },
         ]
       },
       sa-api = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*   After [sbc-pay PR #2265](https://github.com/bcgov/sbc-pay/pull/2265) removed AUTHPAY_GCP_AUTH_KEY, payment-jobs fell back to Application Default Credentials (sa-job) for PubSub publishing. sa-job only had the rolejob role with no pubsub.publisher permissions, causing 403 PermissionDenied errors on all mailer/pay topic publishes in both test and prod.

Grant sa-job roles/pubsub.publisher on the 5 payment PubSub topics in gtksf3-test and gtksf3-prod: 
- account-mailer-{env}
- auth-event-{env}
- namex-pay-{env}
- assets-pay-notification-{env}
- business-pay-{env}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
