### PR TITLE
fix: grant cbaab0-test WIF principal serviceAccountTokenCreator on sa-job (gtksf3-test)

### DIFF
--- a/.github/actions/frontend-deploy/files/cloudbuild.yaml
+++ b/.github/actions/frontend-deploy/files/cloudbuild.yaml
@@ -156,7 +156,7 @@ steps:
     set -euo pipefail  # Added for stricter error handling
 
     apk update
-    apk add jq
+    apk add jq python3 make g++
 
     echo "Step 2: Build application."
     

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -448,6 +448,17 @@ test_projects = {
         description = "Service account used to backup auth db in OpenShift Gold Cluster, as part of disaster recovery plan."
       }
     }
+    resource_iam_bindings = [
+      {
+        resource      = "projects/gtksf3-test/serviceAccounts/sa-job@gtksf3-test.iam.gserviceaccount.com"
+        resource_type = "sa_iam_member"
+        roles         = ["roles/iam.workloadIdentityUser", "roles/iam.serviceAccountTokenCreator"]
+        members       = [
+          # WIF OpenShift Namespace: cbaab0-test
+          "principal://iam.googleapis.com/projects/331250273634/locations/global/workloadIdentityPools/central-keycloak-pool/subject/67adac47-6e8c-41f8-85e5-516af6d08095"
+        ]
+      }
+    ]
   },
   "bor-test" = {
     project_id = "yfjq17-test"


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:* Allow the ftp-poller WIF workload identity (cbaab0-test namespace) to impersonate sa-job@gtksf3-test so it can acquire tokens for Google Cloud Storage access.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
