### PR TITLE
handle more complex json better / update sre-cd-runner image

### DIFF
--- a/images/sre-cd-runner/Dockerfile
+++ b/images/sre-cd-runner/Dockerfile
@@ -1,5 +1,6 @@
 FROM docker:28.1.1 as static-docker-source
-FROM google/cloud-sdk:522.0.0-alpine
+FROM google/cloud-sdk:556.0.0-alpine
+
 COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 
 WORKDIR /app

--- a/images/sre-cd-runner/functions.sh
+++ b/images/sre-cd-runner/functions.sh
@@ -86,7 +86,6 @@ build_and_push_image() {
     fi
 }
 
-# Function to merge two vault files and output a YAML-formatted file
 merge_vaults() {
     local origin_env="$1"
     local update_env="$2"
@@ -94,39 +93,52 @@ merge_vaults() {
 
     declare -A update_values
 
-    # Load update_env values into associative array
     while IFS='=' read -r key value; do
         [[ -z "$key" || "$key" =~ ^# ]] && continue
-        value="${value%\"}"  # Remove trailing quote
-        value="${value#\"}"  # Remove leading quote
         update_values["$key"]="$value"
     done < <(grep -v '^[[:space:]]*$' "$update_env")
 
+    # Remove surrounding quotes from values
+    for key in "${!update_values[@]}"; do
+        val="${update_values[$key]}"
+        val="${val#\'}"
+        val="${val%\'}"
+        val="${val#\"}"
+        val="${val%\"}"
+        update_values["$key"]="$val"
+    done
+
+    # Output as YAML format only
     {
-        # Process origin_env and apply updates
         while IFS='=' read -r key value; do
             [[ -z "$key" || "$key" =~ ^# ]] && continue
+            # Remove surrounding quotes
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#\"}"
+            value="${value%\"}"
+
             if [[ -n "${update_values[$key]+_}" ]]; then
                 val="${update_values[$key]}"
+                unset update_values["$key"]
             else
                 val="$value"
             fi
-            val="${val%\"}"; val="${val#\"}"           # Strip surrounding quotes
-            val="${val//\"/\\\"}"                     # Escape internal quotes
-            echo "$key: \"$val\""
-            unset update_values["$key"]
+            # Escape for YAML
+            val="${val//\\/\\\\}"
+            val="${val//\"/\\\"}"
+            printf '%s: "%s"\n' "$key" "$val"
         done < <(grep -v '^[[:space:]]*$' "$origin_env")
 
-        # Add remaining new keys from update_env
         for key in "${!update_values[@]}"; do
             val="${update_values[$key]}"
-            val="${val%\"}"; val="${val#\"}"
+            val="${val//\\/\\\\}"
             val="${val//\"/\\\"}"
-            echo "$key: \"$val\""
+            printf '%s: "%s"\n' "$key" "$val"
         done
     } > "$output_env"
 
-    echo "🛠️ Updated values written to $output_env"
+    echo "🛠️ Updated values written to $output_env (YAML format)" >&2
 }
 
 # Generate secrets file


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

Built this as 1.0.8 sre-cd-runner, ppr-api and mhr-api are pointing to it in their CDs

1. Quote Removal Order

Original (broken):

bash
value="${value%\"}"  # Remove trailing quote
value="${value#\"}"  # Remove leading quote
This only removed quotes if they were the FIRST and LAST characters, but didn't handle cases where quotes might be nested.

New (working):

bash
val="${val#\'}"   # Remove leading single quote
val="${val%\'}"   # Remove trailing single quote  
val="${val#\"}"   # Remove leading double quote
val="${val%\"}"   # Remove trailing double quote
Removes BOTH single AND double quotes, in the correct order, and does it consistently.

2. Quote Removal Applied to ALL values

Original: Only stripped quotes from update_values (the new values), but NOT from the origin values properly.

New: Strips quotes from EVERY value:

First from all update_values in a dedicated loop
Then from origin values during processing
Then from the final value before output
3. Preserved Special Characters

Original: The sequence val="${val%\"}"; val="${val#\"}" could strip quotes from inside JSON strings if they appeared at boundaries.

New: Only strips quotes that wrap the ENTIRE value, not internal quotes.

4. Escape Order

Both versions do the same escaping, but the new version does it after ensuring no stray wrapper quotes remain.

Example of specific json that was failing - NOTIFY_REVIEW_CONFIG={"url": "https://notify-api-dev-nn.a.run.app/api/v1/notify","subjectApprove":"DEV MHR Registration Completed - {mhr_number}: DO NOT REPLY","subjectDecline":"DEV MHR Registration Declined - {mhr_number}: DO NOT REPLY","bodyApprove": "Your recently submitted MHR {reg_type} registration for {mhr_number} has been approved and completed. The following link is valid for 7 days to download the verification statement for the registration.$$[Verification Statement]({verification_url})","bodyDecline": "Your recently submitted MHR {reg_type} registration for {mhr_number} has been reviewed and declined for the following reason: {reason}$$Your payment with invoice ID {invoice_id} has been refunded. $$[Rejection Notice]({rejection_url})"}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
