### PR TITLE
Grant STRR dashboard read access

### DIFF
--- a/gcp/terraform/_config_project_dev.auto.tfvars
+++ b/gcp/terraform/_config_project_dev.auto.tfvars
@@ -1404,6 +1404,26 @@ dev_projects = {
         ]
        },
       {
+        role    = "roles/monitoring.viewer"
+        members = [
+          "dima.kostenyuk@gov.bc.ca",
+          "jimmy.palelil@gov.bc.ca",
+          "karim.jazzar@gov.bc.ca",
+          "mike.huffman@gov.bc.ca",
+          "olga.potiagalova@gov.bc.ca",
+        ]
+      },
+      {
+        role    = "roles/logging.viewer"
+        members = [
+          "dima.kostenyuk@gov.bc.ca",
+          "jimmy.palelil@gov.bc.ca",
+          "karim.jazzar@gov.bc.ca",
+          "mike.huffman@gov.bc.ca",
+          "olga.potiagalova@gov.bc.ca",
+        ]
+      },
+      {
         role    = "projects/bcrbk9-dev/roles/SRE"
         members = [
           "kial.jinnah@gov.bc.ca"

--- a/gcp/terraform/_config_project_prod.auto.tfvars
+++ b/gcp/terraform/_config_project_prod.auto.tfvars
@@ -1552,6 +1552,26 @@ prod_projects = {
         ]
       },
       {
+        role    = "roles/monitoring.viewer"
+        members = [
+          "dima.kostenyuk@gov.bc.ca",
+          "jimmy.palelil@gov.bc.ca",
+          "karim.jazzar@gov.bc.ca",
+          "mike.huffman@gov.bc.ca",
+          "olga.potiagalova@gov.bc.ca",
+        ]
+      },
+      {
+        role    = "roles/logging.viewer"
+        members = [
+          "dima.kostenyuk@gov.bc.ca",
+          "jimmy.palelil@gov.bc.ca",
+          "karim.jazzar@gov.bc.ca",
+          "mike.huffman@gov.bc.ca",
+          "olga.potiagalova@gov.bc.ca",
+        ]
+      },
+      {
         role    = "projects/bcrbk9-prod/roles/serviceuser"
         members = ["mike.huffman@gov.bc.ca"]
       },

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -1262,6 +1262,26 @@ test_projects = {
         ]
       },
       {
+        role    = "roles/monitoring.viewer"
+        members = [
+          "dima.kostenyuk@gov.bc.ca",
+          "jimmy.palelil@gov.bc.ca",
+          "karim.jazzar@gov.bc.ca",
+          "mike.huffman@gov.bc.ca",
+          "olga.potiagalova@gov.bc.ca",
+        ]
+      },
+      {
+        role    = "roles/logging.viewer"
+        members = [
+          "dima.kostenyuk@gov.bc.ca",
+          "jimmy.palelil@gov.bc.ca",
+          "karim.jazzar@gov.bc.ca",
+          "mike.huffman@gov.bc.ca",
+          "olga.potiagalova@gov.bc.ca",
+        ]
+      },
+      {
         role    = "roles/cloudsql.instanceUser"
         members = ["andriy.bolyachevets@gov.bc.ca"]
       },

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -1252,6 +1252,7 @@ test_projects = {
         role    = "projects/bcrbk9-test/roles/roledeveloper"
         members = [
           "dietrich.wolpert@gov.bc.ca",
+          "dima.kostenyuk@gov.bc.ca",
           "mark.ruffolo@gov.bc.ca",
           "janis.rogers@gov.bc.ca",
           "jimmy.palelil@gov.bc.ca",


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*
- Use `roledeveloper` instead of `SRE` for email log investigation access.
- Add `dima.kostenyuk@gov.bc.ca` to STRR TEST `roledeveloper`.
- Jimmy Palelil already has STRR Dev/TEST `roledeveloper`; Dima already has STRR Dev `roledeveloper`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).