### PR TITLE
Adding roles/cloudtrace.agent role for API service account

### DIFF
--- a/gcp/terraform/_config_project_dev.auto.tfvars
+++ b/gcp/terraform/_config_project_dev.auto.tfvars
@@ -497,7 +497,7 @@ dev_projects = {
         ]
       },
       sa-api = {
-        roles       = ["projects/gtksf3-dev/roles/roleapi", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent"]
+        roles       = ["projects/gtksf3-dev/roles/roleapi", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent", "roles/cloudtrace.agent"]
         description = "Service Account for running api services"
         resource_roles = [
             {

--- a/gcp/terraform/_config_project_other.auto.tfvars
+++ b/gcp/terraform/_config_project_other.auto.tfvars
@@ -317,7 +317,7 @@ other_projects = {
         ]
       },
       sa-api = {
-        roles       = ["projects/gtksf3-tools/roles/roleapi", "roles/cloudsql.client", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent"]
+        roles       = ["projects/gtksf3-tools/roles/roleapi", "roles/cloudsql.client", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent", "roles/cloudtrace.agent"]
         description = "Service Account for running api services"
         resource_roles = [
             {

--- a/gcp/terraform/_config_project_prod.auto.tfvars
+++ b/gcp/terraform/_config_project_prod.auto.tfvars
@@ -700,7 +700,7 @@ prod_projects = {
         ]
       },
       sa-api = {
-        roles       = ["projects/gtksf3-prod/roles/roleapi", "roles/cloudsql.client", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent"]
+        roles       = ["projects/gtksf3-prod/roles/roleapi", "roles/cloudsql.client", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent", "roles/cloudtrace.agent"]
         description = "Service Account for running api services"
         resource_roles = [
             {

--- a/gcp/terraform/_config_project_test.auto.tfvars
+++ b/gcp/terraform/_config_project_test.auto.tfvars
@@ -428,7 +428,7 @@ test_projects = {
         ]
       },
       sa-api = {
-        roles       = ["projects/gtksf3-test/roles/roleapi", "roles/cloudsql.client", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent"]
+        roles       = ["projects/gtksf3-test/roles/roleapi", "roles/cloudsql.client", "roles/iam.serviceAccountTokenCreator", "roles/cloudsql.instanceUser", "roles/serverless.serviceAgent", "roles/cloudtrace.agent"]
         description = "Service Account for running api services"
         resource_roles = [
             {


### PR DESCRIPTION
*Issue #:* [/bcgov/entity/33243](https://app.zenhub.com/workspaces/pay-team-space-649992c7f903a02c9b33009f/issues/gh/bcgov/entity/33243)

*Description of changes:*
- Default service credentials need trace agent role to export the traces to GCP tracing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
