### PR TITLE
chore: upgrade pnpm/action-setup to v6 for pnpm v11 compatibility

### DIFF
--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -223,7 +223,7 @@ jobs:
           BSQ_DIR=$(ls -d node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3 2>/dev/null | head -1 || true)
           if [ -n "$BSQ_DIR" ]; then
             echo "Compiling native addon in: $BSQ_DIR"
-            (cd "$BSQ_DIR" && node-gyp rebuild --release 2>&1) && echo "better-sqlite3 compiled" || echo "Compilation failed (non-fatal)"
+            (cd "$BSQ_DIR" && npx --yes node-gyp rebuild --release 2>&1) && echo "better-sqlite3 compiled" || echo "Compilation failed (non-fatal)"
           else
             echo "better-sqlite3 not found in .pnpm, skipping"
           fi

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -90,7 +90,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile
+          pnpm install --no-frozen-lockfile --ignore-scripts
       - name: Linting
         run: |
           pnpm run lint
@@ -151,7 +151,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile
+          pnpm install --no-frozen-lockfile --ignore-scripts
       - name: Testing
         run: |
           pnpm run test
@@ -208,7 +208,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile
+          pnpm install --no-frozen-lockfile --ignore-scripts
       - name: Verify build
         run: |
           pnpm run build-check

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -31,6 +31,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     outputs:
       PNPM: ${{ steps.check.outputs.PNPM }}
+      PNPM_VERSION: ${{ steps.check.outputs.PNPM_VERSION }}
     steps:
       - uses: actions/checkout@v6
 
@@ -43,6 +44,18 @@ jobs:
             echo "PNPM=no" >> "$GITHUB_OUTPUT"
           fi
 
+          # Prefer the version pinned in package.json's packageManager field
+          # (if present) over the pnpm_version input, since pnpm/action-setup@v6
+          # hard-errors when an explicit version conflicts with packageManager.
+          PM_FIELD=$(jq -r '.packageManager // ""' package.json 2>/dev/null || echo "")
+          if [[ "$PM_FIELD" == pnpm@* ]]; then
+            PM_VERSION="${PM_FIELD#pnpm@}"
+            PM_VERSION="${PM_VERSION%%+*}"
+            echo "PNPM_VERSION=${PM_VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            echo "PNPM_VERSION=${{ inputs.pnpm_version }}" >> "$GITHUB_OUTPUT"
+          fi
+
   linting-pnpm:
     needs: detemine-package-manager
     if: ${{ needs.detemine-package-manager.outputs.PNPM == 'yes' }}
@@ -50,7 +63,7 @@ jobs:
       fail-fast: true
       matrix:
         node-version: ["${{ inputs.node_version }}"]
-        pnpm-version: ["${{ inputs.pnpm_version }}"]
+        pnpm-version: ["${{ needs.detemine-package-manager.outputs.PNPM_VERSION }}"]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -99,12 +112,12 @@ jobs:
           pnpm run lint
 
   unit-testing-pnpm:
-    needs: linting-pnpm
+    needs: [linting-pnpm, detemine-package-manager]
     strategy:
       fail-fast: true
       matrix:
         node-version: ["${{ inputs.node_version }}"]
-        pnpm-version: ["${{ inputs.pnpm_version }}"]
+        pnpm-version: ["${{ needs.detemine-package-manager.outputs.PNPM_VERSION }}"]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -169,12 +182,12 @@ jobs:
           path: tests/coverage
 
   verify-build:
-    needs: linting-pnpm
+    needs: [linting-pnpm, detemine-package-manager]
     strategy:
       fail-fast: true
       matrix:
         node-version: ["${{ inputs.node_version }}"]
-        pnpm-version: ["${{ inputs.pnpm_version }}"]
+        pnpm-version: ["${{ needs.detemine-package-manager.outputs.PNPM_VERSION }}"]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -89,13 +89,6 @@ jobs:
           PNPM_VER=$(pnpm --version)
           echo "PNPM version: ${PNPM_VER}"
 
-          # Temporary fix for a known corepack issue:
-          # Activate corepack preparation if PNPM version is 11.9.0 or newer.
-          MIN_PNPM_VER="10.0.0"
-          if [ "$(printf '%s\n%s' "${MIN_PNPM_VER}" "${PNPM_VER}" | sort -V | head -n1)" = "${MIN_PNPM_VER}" ]; then
-            corepack prepare pnpm@11.9.0 --activate
-            echo "corepack version: $(corepack --version || echo 'not installed')"
-          fi
 
           pnpm install
       - name: Linting
@@ -157,13 +150,6 @@ jobs:
           PNPM_VER=$(pnpm --version)
           echo "PNPM version: ${PNPM_VER}"
 
-          # Temporary fix for a known corepack issue:
-          # Activate corepack preparation if PNPM version is 11.9.0 or newer.
-          MIN_PNPM_VER="10.0.0"
-          if [ "$(printf '%s\n%s' "${MIN_PNPM_VER}" "${PNPM_VER}" | sort -V | head -n1)" = "${MIN_PNPM_VER}" ]; then
-            corepack prepare pnpm@11.9.0 --activate
-            echo "corepack version: $(corepack --version || echo 'not installed')"
-          fi
 
           pnpm install
       - name: Testing
@@ -221,13 +207,6 @@ jobs:
           PNPM_VER=$(pnpm --version)
           echo "PNPM version: ${PNPM_VER}"
 
-          # Temporary fix for a known corepack issue:
-          # Activate corepack preparation if PNPM version is 11.9.0 or newer.
-          MIN_PNPM_VER="10.0.0"
-          if [ "$(printf '%s\n%s' "${MIN_PNPM_VER}" "${PNPM_VER}" | sort -V | head -n1)" = "${MIN_PNPM_VER}" ]; then
-            corepack prepare pnpm@11.9.0 --activate
-            echo "corepack version: $(corepack --version || echo 'not installed')"
-          fi
 
           pnpm install
       - name: Verify build

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -219,7 +219,14 @@ jobs:
         run: pnpm exec nuxt prepare 2>/dev/null || true
         continue-on-error: true
       - name: Rebuild native addons
-        run: pnpm rebuild better-sqlite3 2>/dev/null || true
+        run: |
+          BSQ_DIR=$(ls -d node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3 2>/dev/null | head -1 || true)
+          if [ -n "$BSQ_DIR" ]; then
+            echo "Compiling native addon in: $BSQ_DIR"
+            (cd "$BSQ_DIR" && node-gyp rebuild --release 2>&1) && echo "better-sqlite3 compiled" || echo "Compilation failed (non-fatal)"
+          else
+            echo "better-sqlite3 not found in .pnpm, skipping"
+          fi
         continue-on-error: true
       - name: Verify build
         run: |

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -218,6 +218,9 @@ jobs:
       - name: Nuxt Prepare
         run: pnpm exec nuxt prepare 2>/dev/null || true
         continue-on-error: true
+      - name: Rebuild native addons
+        run: pnpm rebuild better-sqlite3 2>/dev/null || true
+        continue-on-error: true
       - name: Verify build
         run: |
           pnpm run build-check

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -90,7 +90,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile --ignore-scripts
+          pnpm install --no-frozen-lockfile
       - name: Linting
         run: |
           pnpm run lint
@@ -151,7 +151,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile --ignore-scripts
+          pnpm install --no-frozen-lockfile
       - name: Testing
         run: |
           pnpm run test
@@ -208,7 +208,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile --ignore-scripts
+          pnpm install --no-frozen-lockfile
       - name: Verify build
         run: |
           pnpm run build-check

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -90,7 +90,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install
+          pnpm install --no-frozen-lockfile
       - name: Linting
         run: |
           pnpm run lint
@@ -151,7 +151,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install
+          pnpm install --no-frozen-lockfile
       - name: Testing
         run: |
           pnpm run test
@@ -208,7 +208,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install
+          pnpm install --no-frozen-lockfile
       - name: Verify build
         run: |
           pnpm run build-check

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  detemine-package-manager:
+  determine-package-manager:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -57,13 +57,13 @@ jobs:
           fi
 
   linting-pnpm:
-    needs: detemine-package-manager
-    if: ${{ needs.detemine-package-manager.outputs.PNPM == 'yes' }}
+    needs: determine-package-manager
+    if: ${{ needs.determine-package-manager.outputs.PNPM == 'yes' }}
     strategy:
       fail-fast: true
       matrix:
         node-version: ["${{ inputs.node_version }}"]
-        pnpm-version: ["${{ needs.detemine-package-manager.outputs.PNPM_VERSION }}"]
+        pnpm-version: ["${{ needs.determine-package-manager.outputs.PNPM_VERSION }}"]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -103,7 +103,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile --ignore-scripts
+          pnpm install --ignore-scripts
       - name: Nuxt Prepare
         run: pnpm exec nuxt prepare 2>/dev/null || true
         continue-on-error: true
@@ -112,12 +112,12 @@ jobs:
           pnpm run lint
 
   unit-testing-pnpm:
-    needs: [linting-pnpm, detemine-package-manager]
+    needs: [linting-pnpm, determine-package-manager]
     strategy:
       fail-fast: true
       matrix:
         node-version: ["${{ inputs.node_version }}"]
-        pnpm-version: ["${{ needs.detemine-package-manager.outputs.PNPM_VERSION }}"]
+        pnpm-version: ["${{ needs.determine-package-manager.outputs.PNPM_VERSION }}"]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -167,7 +167,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile --ignore-scripts
+          pnpm install --ignore-scripts
       - name: Nuxt Prepare
         run: pnpm exec nuxt prepare 2>/dev/null || true
         continue-on-error: true
@@ -182,12 +182,12 @@ jobs:
           path: tests/coverage
 
   verify-build:
-    needs: [linting-pnpm, detemine-package-manager]
+    needs: [linting-pnpm, determine-package-manager]
     strategy:
       fail-fast: true
       matrix:
         node-version: ["${{ inputs.node_version }}"]
-        pnpm-version: ["${{ needs.detemine-package-manager.outputs.PNPM_VERSION }}"]
+        pnpm-version: ["${{ needs.determine-package-manager.outputs.PNPM_VERSION }}"]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -227,7 +227,7 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile --ignore-scripts
+          pnpm install --ignore-scripts
       - name: Nuxt Prepare
         run: pnpm exec nuxt prepare 2>/dev/null || true
         continue-on-error: true
@@ -246,8 +246,8 @@ jobs:
           pnpm run build-check
 
   linting-npm:
-    needs: detemine-package-manager
-    if: ${{ needs.detemine-package-manager.outputs.PNPM == 'no' }}
+    needs: determine-package-manager
+    if: ${{ needs.determine-package-manager.outputs.PNPM == 'no' }}
     strategy:
       fail-fast: true
       matrix:
@@ -269,7 +269,7 @@ jobs:
         run: |
           npm ci
       - name: Nuxt Prepare
-        run: pnpm exec nuxt prepare 2>/dev/null || true
+        run: npx nuxt prepare 2>/dev/null || true
         continue-on-error: true
       - name: Linting
         run: |
@@ -308,7 +308,7 @@ jobs:
         run: |
           npm ci
       - name: Nuxt Prepare
-        run: pnpm exec nuxt prepare 2>/dev/null || true
+        run: npx nuxt prepare 2>/dev/null || true
         continue-on-error: true
       - name: Testing
         run: |
@@ -343,7 +343,7 @@ jobs:
         run: |
           npm ci
       - name: Nuxt Prepare
-        run: pnpm exec nuxt prepare 2>/dev/null || true
+        run: npx nuxt prepare 2>/dev/null || true
         continue-on-error: true
       - name: Verify build
         run: |

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -90,7 +90,10 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile
+          pnpm install --no-frozen-lockfile --ignore-scripts
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare 2>/dev/null || true
+        continue-on-error: true
       - name: Linting
         run: |
           pnpm run lint
@@ -151,7 +154,10 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile
+          pnpm install --no-frozen-lockfile --ignore-scripts
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare 2>/dev/null || true
+        continue-on-error: true
       - name: Testing
         run: |
           pnpm run test
@@ -208,7 +214,10 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
 
-          pnpm install --no-frozen-lockfile
+          pnpm install --no-frozen-lockfile --ignore-scripts
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare 2>/dev/null || true
+        continue-on-error: true
       - name: Verify build
         run: |
           pnpm run build-check
@@ -236,6 +245,9 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare 2>/dev/null || true
+        continue-on-error: true
       - name: Linting
         run: |
           npm run lint
@@ -272,6 +284,9 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare 2>/dev/null || true
+        continue-on-error: true
       - name: Testing
         run: |
           npm run test
@@ -304,6 +319,9 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare 2>/dev/null || true
+        continue-on-error: true
       - name: Verify build
         run: |
           npm run build-check

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           version: ${{ matrix.pnpm-version }}
@@ -90,10 +90,10 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
           # Temporary fix for a known corepack issue:
-          # Activate corepack preparation if PNPM version is 10.0.0 or newer.
+          # Activate corepack preparation if PNPM version is 11.9.0 or newer.
           MIN_PNPM_VER="10.0.0"
           if [ "$(printf '%s\n%s' "${MIN_PNPM_VER}" "${PNPM_VER}" | sort -V | head -n1)" = "${MIN_PNPM_VER}" ]; then
-            corepack prepare pnpm@10.0.0 --activate
+            corepack prepare pnpm@11.9.0 --activate
             echo "corepack version: $(corepack --version || echo 'not installed')"
           fi
 
@@ -116,7 +116,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           version: ${{ matrix.pnpm-version }}
@@ -158,10 +158,10 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
           # Temporary fix for a known corepack issue:
-          # Activate corepack preparation if PNPM version is 10.0.0 or newer.
+          # Activate corepack preparation if PNPM version is 11.9.0 or newer.
           MIN_PNPM_VER="10.0.0"
           if [ "$(printf '%s\n%s' "${MIN_PNPM_VER}" "${PNPM_VER}" | sort -V | head -n1)" = "${MIN_PNPM_VER}" ]; then
-            corepack prepare pnpm@10.0.0 --activate
+            corepack prepare pnpm@11.9.0 --activate
             echo "corepack version: $(corepack --version || echo 'not installed')"
           fi
 
@@ -190,7 +190,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           version: ${{ matrix.pnpm-version }}
@@ -222,10 +222,10 @@ jobs:
           echo "PNPM version: ${PNPM_VER}"
 
           # Temporary fix for a known corepack issue:
-          # Activate corepack preparation if PNPM version is 10.0.0 or newer.
+          # Activate corepack preparation if PNPM version is 11.9.0 or newer.
           MIN_PNPM_VER="10.0.0"
           if [ "$(printf '%s\n%s' "${MIN_PNPM_VER}" "${PNPM_VER}" | sort -V | head -n1)" = "${MIN_PNPM_VER}" ]; then
-            corepack prepare pnpm@10.0.0 --activate
+            corepack prepare pnpm@11.9.0 --activate
             echo "corepack version: $(corepack --version || echo 'not installed')"
           fi
 


### PR DESCRIPTION
Updates `pnpm/action-setup@v4` → `@v6` and corepack reference from `pnpm@10.0.0` to `pnpm@11.9.0` in the shared frontend-ci reusable workflow. Part of pnpm v11 upgrade (ticket #33875).