### PR TITLE
REGBACKLOG-333: Manage STRR sandbox callback subscription

### DIFF
--- a/gcp/terraform/_config_project_other.auto.tfvars
+++ b/gcp/terraform/_config_project_other.auto.tfvars
@@ -786,6 +786,13 @@ other_projects = {
       sa-pubsub = {
         roles       = ["roles/iam.serviceAccountTokenCreator", "roles/pubsub.publisher", "roles/pubsub.subscriber"]
         description = "Service Account for running pubsub services"
+        resource_roles = [
+          {
+            resource      = "projects/bcrbk9-tools/locations/northamerica-northeast1/services/batch-permit-listener-sandbox"
+            roles         = ["roles/run.invoker"]
+            resource_type = "cloud_run"
+          }
+        ]
       },
       sa-db-migrate = {
         roles       = ["projects/bcrbk9-tools/roles/roledbmigrate"]

--- a/gcp/terraform/strr_pubsub.tf
+++ b/gcp/terraform/strr_pubsub.tf
@@ -1,0 +1,59 @@
+locals {
+  manage_strr_sandbox_bulk_validation_response = terraform.workspace == "other"
+}
+
+data "google_pubsub_topic" "strr_sandbox_bulk_validation_response" {
+  count = local.manage_strr_sandbox_bulk_validation_response ? 1 : 0
+
+  name    = "strr-bulk-validation-response-sandbox"
+  project = "bcrbk9-tools"
+}
+
+resource "google_pubsub_subscription" "strr_sandbox_bulk_validation_response" {
+  count = local.manage_strr_sandbox_bulk_validation_response ? 1 : 0
+
+  name    = "strr-bulk-validation-response-sandbox-sub"
+  project = "bcrbk9-tools"
+  topic   = data.google_pubsub_topic.strr_sandbox_bulk_validation_response[0].id
+
+  ack_deadline_seconds       = 30
+  message_retention_duration = "604800s"
+  retain_acked_messages      = false
+
+  expiration_policy {
+    ttl = ""
+  }
+
+  dead_letter_policy {
+    dead_letter_topic     = "projects/bcrbk9-tools/topics/strr-bulk-validation-response-dlq-sandbox"
+    max_delivery_attempts = 5
+  }
+
+  push_config {
+    push_endpoint = "https://batch-permit-listener-sandbox-865508335279.northamerica-northeast1.run.app/bulk-validation-response"
+
+    attributes = {
+      x-goog-version = "v1"
+    }
+
+    oidc_token {
+      service_account_email = "sa-pubsub@bcrbk9-tools.iam.gserviceaccount.com"
+      audience              = "https://batch-permit-listener-sandbox-865508335279.northamerica-northeast1.run.app"
+    }
+  }
+
+  retry_policy {
+    minimum_backoff = "10s"
+    maximum_backoff = "600s"
+  }
+}
+
+# Adopt the Sandbox subscription created during REGBACKLOG-333.
+import {
+  for_each = local.manage_strr_sandbox_bulk_validation_response ? toset([
+    "projects/bcrbk9-tools/subscriptions/strr-bulk-validation-response-sandbox-sub"
+  ]) : toset([])
+
+  to = google_pubsub_subscription.strr_sandbox_bulk_validation_response[0]
+  id = each.value
+}


### PR DESCRIPTION
*Issue #:* REGBACKLOG-333

*Description of changes:*

- Adopt the manually created Sandbox bulk-validation response subscription into Terraform.
- Grant sa-pubsub Cloud Run invoker access only on batch-permit-listener-sandbox.
- Preserve the existing topic, callback endpoint, dead-letter policy, and retry policy.
- Increase the push acknowledgement deadline to 30 seconds and disable subscription expiry.
- Configure the Cloud Run service URL as the OIDC audience.

*Validation:*

- terraform validate
- Terraform formatting and diff checks
- Targeted other workspace plan: 1 import, 1 add, 1 in-place update, 0 destroys

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).