### PR TITLE
iam(dev): grant paul.adeyinka -> compute.instanceAdmin.v1 + loadBalan…

### DIFF
--- a/gcp/terraform/_config_project_dev.auto.tfvars
+++ b/gcp/terraform/_config_project_dev.auto.tfvars
@@ -753,7 +753,15 @@ dev_projects = {
       },
       {
         role    = "roles/iam.serviceAccountUser"
-        members = ["steven.chen@gov.bc.ca"]
+        members = ["steven.chen@gov.bc.ca", "paul.adeyinka@gov.bc.ca"]
+      },
+      {
+        role    = "roles/compute.instanceAdmin.v1"
+        members = ["paul.adeyinka@gov.bc.ca"]
+      },
+      {
+        role    = "roles/compute.loadBalancerAdmin"
+        members = ["paul.adeyinka@gov.bc.ca"]
       },
       {
         role = "roles/compute.osAdminLogin"


### PR DESCRIPTION
…cerAdmin + serviceAccountUser on bcr-businesses-dev

- Scope: project (bcr-businesses-dev / a083gt-dev)
- Justification: enables paul.adeyinka to run the NameX Solr VM deploy script (VM lifecycle, regional LB backend management, template SA impersonation)
- Skipped duplicates: iap.tunnelResourceAccessor (already granted), compute.osLogin (osAdminLogin already granted, superset)
- Plan: ./tf.sh plan dev -> 3 to add, 0 to change, 0 to destroy

*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
