### PR TITLE
iam(dev): grant paul.adeyinka -> roles/compute.networkUser on common-dev

### DIFF
--- a/gcp/terraform/_config_project_dev.auto.tfvars
+++ b/gcp/terraform/_config_project_dev.auto.tfvars
@@ -147,6 +147,10 @@ dev_projects = {
           "sumesh.kariyil@gov.bc.ca",
         ]
       },
+      {
+        role    = "roles/compute.networkUser"
+        members = ["paul.adeyinka@gov.bc.ca"]
+      },
     ]
     resource_iam_bindings = [
       {


### PR DESCRIPTION
- Scope: project (common-dev / c4hnrd-dev), Shared VPC host
- Justification: enable compute.subnetworks.use on host project so namex-solr leader VM rotation from service project bcr-businesses-dev can consume subnet bcr-common-dev-montreal
- Plan: ./tf.sh plan dev -> 1 to add, 0 to change, 0 to destroy

*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
