### PR TITLE
fix: bump frontend-cd default/fallback pnpm version to 11.9.0

### DIFF
--- a/.github/actions/frontend-deploy/files/cloudbuild.yaml
+++ b/.github/actions/frontend-deploy/files/cloudbuild.yaml
@@ -169,8 +169,8 @@ steps:
     if [ -f "pnpm-lock.yaml" ] || ([ -f "package.json" ] && [[ "$(jq -r '.packageManager // ""' package.json)" == "pnpm"* ]]); then
 
       # PNPM-specific build process
-      # Install pnpm using the specified version or default to "latest-9" if _PNPM_VERSION is not set.
-      npm install --global pnpm@${_PNPM_VERSION:-latest-9}
+      # Install pnpm using the specified version or default to "11.9.0" if _PNPM_VERSION is not set.
+      npm install --global pnpm@${_PNPM_VERSION:-11.9.0}
 
       PNPM_VER=$(pnpm --version)
       echo "PNPM version: ${PNPM_VER}"

--- a/.github/workflows/frontend-cd.yaml
+++ b/.github/workflows/frontend-cd.yaml
@@ -14,7 +14,7 @@ on:
         default: "1.0.1"
       pnpm_version:
         type: string
-        default: "latest-9"
+        default: "11.9.0"
       app_name:
         required: true
         type: string


### PR DESCRIPTION
## Summary
- `frontend-ci.yaml` was updated for the pnpm v11 migration in #369, but `frontend-cd.yaml` (the actual deploy pipeline) was never touched — its `pnpm_version` input still defaults to `"latest-9"`, and the fallback in the shared `cloudbuild.yaml` deploy template also defaulted to `"latest-9"`.
- Any consuming app's `*-cd.yaml`/`*-cd.yml` that doesn't explicitly pass `pnpm_version` inherits this stale default, so its production deploy build runs on a completely different, unvalidated pnpm major version than what CI checked.
- Confirmed empirically in live production Cloud Build logs: bcregistry's 2026-07-29 deploy and pay-ui's 2026-07-30 deploy both ran `PNPM version: 9.15.9`, not the `11.9.0` validated by their CI checks.
- Bumped both the `pnpm_version` input default in `frontend-cd.yaml` and the `${_PNPM_VERSION:-...}` fallback in `.github/actions/frontend-deploy/files/cloudbuild.yaml` to `11.9.0`.

## Test plan
- [ ] Confirm a consuming repo's next deploy (e.g. bcregistry or pay-ui, once merged) shows `PNPM version: 11.9.0` in its Cloud Build log
- [ ] Repos that explicitly hardcode a different `pnpm_version` in their own `*-cd.yaml` (e.g. business-ui's corps/person-roles/registry-home, bcros-common's documents-ui, name-examination) still need separate fixes — this PR only fixes the shared default