### PR TITLE
fix: resolve _PNPM_VERSION substitution before applying bash default

### DIFF
--- a/.github/actions/frontend-deploy/files/cloudbuild.yaml
+++ b/.github/actions/frontend-deploy/files/cloudbuild.yaml
@@ -169,8 +169,15 @@ steps:
     if [ -f "pnpm-lock.yaml" ] || ([ -f "package.json" ] && [[ "$(jq -r '.packageManager // ""' package.json)" == "pnpm"* ]]); then
 
       # PNPM-specific build process
-      # Install pnpm using the specified version or default to "11.9.0" if _PNPM_VERSION is not set.
-      npm install --global pnpm@${_PNPM_VERSION:-11.9.0}
+      # Install pnpm using the specified version, or default to "11.9.0" if _PNPM_VERSION is not set.
+      # Substitution is resolved into its own variable first -- combining Cloud Build's
+      # ${_VAR} substitution with bash's ${VAR:-default} syntax in one token is ambiguous
+      # and silently installs the wrong pnpm version.
+      PNPM_VERSION_TO_INSTALL="${_PNPM_VERSION}"
+      if [ -z "$PNPM_VERSION_TO_INSTALL" ]; then
+        PNPM_VERSION_TO_INSTALL="11.9.0"
+      fi
+      npm install --global pnpm@${PNPM_VERSION_TO_INSTALL}
 
       PNPM_VER=$(pnpm --version)
       echo "PNPM version: ${PNPM_VER}"


### PR DESCRIPTION
## Summary
Follow-up to #377, which fixed the `pnpm_version` default/fallback to `11.9.0`. That fix set the default correctly, but the actual install line in the shared deploy `cloudbuild.yaml` combined Cloud Build's own `${_VAR}` substitution with bash's `${VAR:-default}` syntax in a single token:

```bash
npm install --global pnpm@${_PNPM_VERSION:-11.9.0}
```

**Confirmed empirically in a real production deploy** (pay-ui, run [30846827083](https://github.com/bcgov/pay-ui/actions/runs/30846827083), target `prod`, 2026-08-03): the GH Actions step correctly passed `_PNPM_VERSION="11.9.0"` to `gcloud builds submit`, but the resulting Cloud Build log showed `PNPM version: 10.17.1` — neither the passed-in value nor the intended default. Cloud Build's substitution appears to match only the `${_PNPM_VERSION` prefix (there's no immediate closing brace, since `:-11.9.0}` follows), leaving that suffix as literal text glued onto the installed package spec, so npm ends up installing something other than what was intended.

## Fix
Resolve the substitution into its own plain bash variable on its own line first, then apply the default-value check separately — so Cloud Build only ever needs to match a clean, unambiguous `${_PNPM_VERSION}` token, and bash's own default logic runs afterward with no Cloud Build interaction.

## Test plan
- [ ] Trigger a manual redeploy (e.g. pay-ui or bcregistry, `workflow_dispatch`) once merged and confirm the Cloud Build log shows `PNPM version: 11.9.0`