### PR TITLE
fix: install pnpm via corepack instead of npm --global in Cloud Build

### DIFF
--- a/.github/actions/frontend-deploy/files/cloudbuild.yaml
+++ b/.github/actions/frontend-deploy/files/cloudbuild.yaml
@@ -171,24 +171,25 @@ steps:
       # PNPM-specific build process
       # Install pnpm using the specified version, or default to "11.9.0" if _PNPM_VERSION is not set.
       # Substitution is resolved into its own variable first -- combining Cloud Build's
-      # ${_VAR} substitution with bash's ${VAR:-default} syntax in one token is ambiguous
-      # and silently installs the wrong pnpm version.
+      # ${_VAR} substitution with bash's ${VAR:-default} syntax in one token is ambiguous.
       PNPM_VERSION_TO_INSTALL="${_PNPM_VERSION}"
       if [ -z "$PNPM_VERSION_TO_INSTALL" ]; then
         PNPM_VERSION_TO_INSTALL="11.9.0"
       fi
-      npm install --global pnpm@${PNPM_VERSION_TO_INSTALL}
+
+      # Use corepack (not `npm install --global pnpm@X`) as the source of truth for which
+      # pnpm binary actually runs. In this build image `pnpm` resolves to a corepack shim
+      # that takes PATH precedence over whatever npm's global install links -- confirmed by
+      # a real deploy where `npm install --global pnpm@11.9.0` "succeeded" but `pnpm --version`
+      # still reported an unrelated 10.x. Activating via corepack directly controls that shim.
+      echo "which pnpm (before activation): $(which pnpm || echo 'not found')"
+      corepack enable
+      corepack prepare "pnpm@${PNPM_VERSION_TO_INSTALL}" --activate
+      echo "corepack version: $(corepack --version || echo 'not installed')"
+      echo "which pnpm (after activation): $(which pnpm || echo 'not found')"
 
       PNPM_VER=$(pnpm --version)
       echo "PNPM version: ${PNPM_VER}"
-
-      # Temporary fix for a known corepack issue:
-      # Activate corepack preparation if PNPM version is 10.0.0 or newer.
-      MIN_PNPM_VER="10.0.0"
-      if [ "$(printf '%s\n%s' "${MIN_PNPM_VER}" "${PNPM_VER}" | sort -V | head -n1)" = "${MIN_PNPM_VER}" ]; then
-        corepack prepare pnpm@10.0.0 --activate
-        echo "corepack version: $(corepack --version || echo 'not installed')"
-      fi
 
       if [ -f "pnpm-lock.yaml" ]; then
         pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
## Summary
Follow-up to #377 and #378. After both merged, I triggered a real prod redeploy of pay-ui to verify -- it **still** showed `PNPM version: 10.17.1`, not `11.9.0`. Confirmed via exact file size (10058 bytes, matching `main` precisely) that the correctly-fixed `cloudbuild.yaml` was what actually got fetched into the build, ruling out caching/staleness. So `#378`'s theory (Cloud Build substitution parsing) wasn't the real root cause.

**Actual root cause**: in this build image, `npm install --global pnpm@11.9.0` reports success ("added 1 package"), but the `pnpm` command that resolves immediately afterward is a *different* binary -- almost certainly a corepack shim baked into the image that takes PATH precedence over wherever npm's global install links. The existing "temporary fix for a known corepack issue" block a few lines below (hardcoded `corepack prepare pnpm@10.0.0 --activate`) was silently winning every time, since its guard condition (`PNPM_VER >= 10.0.0`) is always true now that we're targeting 11.x.

## Fix
Stop fighting corepack and make it the actual install mechanism: `corepack enable && corepack prepare pnpm@X --activate`. Removed the now-redundant/conflicting hardcoded `10.0.0` block. Added `which pnpm` before/after activation as a standing diagnostic, since this class of bug produced a "successful" build with the wrong toolchain silently -- invisible without explicitly checking which binary resolves.

## Test plan
- [ ] Trigger a redeploy to a **non-prod** target (dev/test) once merged and confirm the log shows `PNPM version: 11.9.0` and the `which pnpm` diagnostic lines
- [ ] Only then re-verify against prod (pay-ui or bcregistry)